### PR TITLE
Remove a sentence that encourages users to send us emails with questions

### DIFF
--- a/overview.md
+++ b/overview.md
@@ -16,5 +16,3 @@ Jump to the section that seems most helpful to you:
 Need an overview of how to partner with us on a Platform integration? Get started on our [Partnership](partnership.md) page.
 Learn about our recommendations for copywriting and styling Typekit-related features in our [Patterns](patterns.md) for good typographic UI.
 Get the full, detailed developer resources for using [Typekit Platform APIs](api_reference.md).
-
-Questions? Send us an <a href="mailto:fontintegrations@adobe.com">email</a>. We look forward to working with you!


### PR DESCRIPTION
We no longer support this API externally and don't need to be supporting it anymore